### PR TITLE
Fix redundant new line between from imports and relative imports

### DIFF
--- a/reorder_python_imports/main.py
+++ b/reorder_python_imports/main.py
@@ -278,7 +278,9 @@ def apply_import_sorting(
                 last_import_obj = import_obj
                 new_imports.append(import_obj_to_partition[import_obj])
 
-        new_imports.append(CodePartition(CodeType.NON_CODE, '\n'))
+        # The new line may has added by separate_from_import option
+        if new_imports and new_imports[-1].src != '\n':
+            new_imports.append(CodePartition(CodeType.NON_CODE, '\n'))
 
         if relative_imports:
             relative_imports.insert(0, CodePartition(CodeType.NON_CODE, '\n'))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -649,3 +649,34 @@ def test_separate_from_import_integration():
         'from . import bar\n'
         'from foo import bar\n'
     )
+
+
+@pytest.mark.usefixtures('in_tmpdir')
+def test_separate_from_import_and_relative_integration():
+    os.makedirs('foo/bar')
+    io.open('foo/__init__.py', 'w').close()
+    io.open('foo/bar/__init__.py', 'w').close()
+
+    with io.open('foo/foo.py', 'w') as foo_file:
+        foo_file.write(
+            'import thirdparty\n'
+            'from thirdparty import foo\n'
+            'from . import bar\n'
+        )
+
+    main(('foo/foo.py',))
+    assert io.open('foo/foo.py').read() == (
+        'import thirdparty\n'
+        'from thirdparty import foo\n'
+        '\n'
+        'from . import bar\n'
+    )
+
+    main(('foo/foo.py', '--separate-from-import', '--separate-relative'))
+    assert io.open('foo/foo.py').read() == (
+        'import thirdparty\n'
+        '\n'
+        'from thirdparty import foo\n'
+        '\n'
+        'from . import bar\n'
+    )


### PR DESCRIPTION
With options: `--separate-relative` and `--separate-from-import` in same time, if relative imports after third party from imports, there will be a redundant new line between them.

Instead:

```python
from thirdparty import foo


from . import bar
```

with:

```python
from thirdparty import foo

from . import bar
```
Related: #22 #21 #19 #20 