### PR TITLE
Print filename for unreadable files.

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -437,7 +437,15 @@ def main(argv=None):
 
     retv = 0
     for filename in args.filenames:
-        contents = io.open(filename).read()
+        try:
+            contents = io.open(filename, encoding='UTF-8').read()
+        except UnicodeDecodeError:
+            print(
+                '{} is non-utf-8 (not supported)'.format(filename),
+                file=sys.stderr,
+            )
+            raise
+
         new_contents = fix_file_contents(
             contents,
             imports_to_add=args.add_import,

--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -344,8 +344,8 @@ def report_diff(contents, new_contents, filename):
 
 def apply_reordering(new_contents, filename):
     print('Reordering imports in {}'.format(filename))
-    with io.open(filename, 'w') as f:
-        f.write(new_contents)
+    with open(filename, 'wb') as f:
+        f.write(new_contents.encode('UTF-8'))
 
 
 def _add_future_options(parser):
@@ -437,8 +437,10 @@ def main(argv=None):
 
     retv = 0
     for filename in args.filenames:
+        with open(filename, 'rb') as f:
+            contents_bytes = f.read()
         try:
-            contents = io.open(filename, encoding='UTF-8').read()
+            contents = contents_bytes.decode('UTF-8')
         except UnicodeDecodeError:
             print(
                 '{} is non-utf-8 (not supported)'.format(filename),

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -721,3 +721,13 @@ def test_can_remove_multiple_at_once(tmpdir):
     f.write('import argparse\nimport os\nimport sys\n')
     assert main((str(f), '--remove-import', 'import os, sys'))
     assert f.read() == 'import argparse\n'
+
+
+def test_unreadable_files_print_filename(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write_binary(b'\x98\xef\x12...')
+    filename = str(f)
+    with pytest.raises(UnicodeDecodeError):
+        main([filename])
+    _, err = capsys.readouterr()
+    assert filename in err


### PR DESCRIPTION
The hook does not print debugging info when it fails to read a file, which makes it difficult to fix the root cause:

```
Trim Trailing Whitespace.................................................Passed
Reorder python imports...................................................Failed
hookid: reorder-python-imports

Traceback (most recent call last):
  File "/root/.cache/pre-commit/repob4ag864j/py_env-python3/bin/reorder-python-imports", line 11, in <module>
    sys.exit(main())
  File "/root/.cache/pre-commit/repob4ag864j/py_env-python3/lib/python3.4/site-packages/reorder_python_imports.py", line 440, in main
    contents = io.open(filename).read()
  File "/root/.cache/pre-commit/repob4ag864j/py_env-python3/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 2328: ordinal not in range(128)

Add trailing commas......................................................Passed
```

This adds a single line to let the user know the offending file:

```
Reorder python imports...................................................Failed
hookid: reorder-python-imports

Issue reading from file: tests/conftest.py
Traceback (most recent call last):
  File "/root/.cache/pre-commit/repox1ve0jjg/py_env-python3/lib/python3.4/site-packages/reorder_python_imports.py", line 442, in main
    contents = io.open(filename).read()
  File "/root/.cache/pre-commit/repox1ve0jjg/py_env-python3/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 2214: ordinal not in range(128)

Add trailing commas......................................................Passed
```

Which the user can then debug:
```shell
╭─@ringo ~/code/reddit-service-news ‹python-2.7.10› ‹wting_add_reorder_imports_precommit_hook•b3578cf›
╰─ cat tests/conftest.py | head -c 2218 | tail -c 10                                         2018.09.04 20:39:01 PDT
Title 🎉%
```

I'm not sure if this better than simply ignoring ascii decode errors since we only really care about the import lines, and surely people are only using ascii there?

```python
            contents = io.open(filename, errors='replace').read()
```