### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,22 @@
 exclude: ^test_data/
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v2.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-yaml
     -   id: debug-statements
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/pre-commit/pre-commit
-    rev: v1.7.0
+    rev: v1.11.2
     hooks:
     -   id: validate_manifest
 -   repo: https://github.com/asottile/reorder_python_imports
@@ -22,10 +25,10 @@ repos:
     -   id: reorder-python-imports
         language_version: python3
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.2.0
+    rev: v1.8.0
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v0.6.4
+    rev: v0.7.1
     hooks:
     -   id: add-trailing-comma


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos