### PR TITLE
Introduce import re-writing from `import ..` to `from .. import ..`

### DIFF
--- a/test_data/inputs/enforce_froms.py
+++ b/test_data/inputs/enforce_froms.py
@@ -1,0 +1,7 @@
+import random
+import time
+
+def foo():
+    bar = random.random()
+    baz = random.randint(1, 10)
+    time.time()

--- a/test_data/outputs/enforce_froms.py
+++ b/test_data/outputs/enforce_froms.py
@@ -1,0 +1,8 @@
+import time
+from random import randint
+from random import random
+
+def foo():
+    bar = random()
+    baz = randint(1, 10)
+    time.time()

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -594,7 +594,9 @@ def test_fix_file_contents(filename):
         input_contents = f.read()
     with io.open(os.path.join('test_data/outputs', filename)) as f:
         expected = f.read()
-    assert fix_file_contents(input_contents) == expected
+    assert fix_file_contents(
+        input_contents, imports_to_enforce_from=('random',),
+    ) == expected
 
 
 @tfiles
@@ -608,10 +610,12 @@ def test_integration_main(filename, tmpdir):
     test_file.write(input_contents)
 
     # Check return value with --diff-only
-    retv_diff = main((str(test_file), '--diff-only'))
+    retv_diff = main((
+        str(test_file), '--diff-only', '--enforce-from-import=random',
+    ))
     assert retv_diff == int(input_contents != expected)
 
-    retv = main((str(test_file),))
+    retv = main((str(test_file), '--enforce-from-import=random'))
     # Check return value
     assert retv == int(input_contents != expected)
 


### PR DESCRIPTION
Hi @asottile! This is my first PR to `asottile/reorder_python_imports` and introduces an entirely new feature, so let me know what I can do to help make this review go smoothly, if you're interested in adding this feature-set to your module. Happy to make any changes you request.

This changeset introduces the new flag `--enforce-from-import` which can be specified to require certain modules to be imported with `from .. import ..` syntax rather than `import ..`. Also included is the ability to re-write code to obey this restriction, eg. when `--diff-only` is unset.

The goal here is to allow users to set rules in terms of how certain imports should be used -- for example, on my team we want to prevent ourselves from running `import typing` directly, but rather require we import only the necessary types within `typing`, eg. `from typing import List`, etc.