### PR TITLE
Add --quiet option

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -460,7 +460,8 @@ def _fix_file(filename, args):
             print('==> {} <=='.format(filename), file=sys.stderr)
             print(new_contents, end='')
         else:
-            print('Reordering imports in {}'.format(filename))
+            if not args.quiet:
+                print('Reordering imports in {}'.format(filename))
             with open(filename, 'wb') as f:
                 f.write(new_contents.encode('UTF-8'))
 
@@ -656,6 +657,10 @@ def main(argv=None):
             '(Deprecated) '
             'Print the output of a single file after reordering.'
         ),
+    )
+    group.add_argument(
+        '--quiet', action='store_true',
+        help='Do not print user messages on success.',
     )
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument(

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -955,3 +955,25 @@ def test_exit_zero_even_if_changed(tmpdir):
     assert not main((str(f), '--exit-zero-even-if-changed'))
     assert f.read() == 'import os\nimport sys\n'
     assert not main((str(f), '--exit-zero-even-if-changed'))
+
+
+def test_user_messages_on_file_change(tmpdir, capsys):
+    f1 = tmpdir.join('changed1.py')
+    f1.write('import os,sys')
+    f2 = tmpdir.join('changed2.py')
+    f2.write('import sys\nimport os\n')
+    f3 = tmpdir.join('unchanged.py')
+    f3.write('import os\nimport sys\n')
+    main((str(f1), str(f2), str(f3)))
+    out, _ = capsys.readouterr()
+    assert 'Reordering imports in {}'.format(f1) in out
+    assert 'Reordering imports in {}'.format(f2) in out
+    assert 'Reordering imports in {}'.format(f3) not in out
+
+
+def test_no_output_on_success_if_quiet(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write('import os,sys')
+    main((str(f), '--quiet'))
+    out = ''.join(capsys.readouterr())
+    assert not out


### PR DESCRIPTION
Added a _--quiet_ args option. When used, user messages on success (Reordering imports in …) are suppressed. Similar to [Black’s](https://github.com/psf/black) [_--quiet_](https://github.com/psf/black/blob/ffa676cd7d332e9fa5808d824f5a31f03ab9a5d0/black.py#L335) option.

Steps to reproduce:

1. Create a file that would be fixed by _reorder_python_imports_.

```python
import ast
import argparse
```

2. Run _reorder_python_imports_ with the _--quiet_ option. `reorder_python_imports --quiet demo.py`
3. See that the contents of the Python file changed, but no output was printed.

Together with _--exit-zero-even-if-changed_, this makes _reorder_python_imports_ a more well-behaved UNIX tool.