### PR TITLE
Print success messages on stderr

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -460,7 +460,7 @@ def _fix_file(filename, args):
             print('==> {} <=='.format(filename), file=sys.stderr)
             print(new_contents, end='')
         else:
-            print('Reordering imports in {}'.format(filename))
+            print('Reordering imports in {}'.format(filename), file=sys.stderr)
             with open(filename, 'wb') as f:
                 f.write(new_contents.encode('UTF-8'))
 

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -955,3 +955,12 @@ def test_exit_zero_even_if_changed(tmpdir):
     assert not main((str(f), '--exit-zero-even-if-changed'))
     assert f.read() == 'import os\nimport sys\n'
     assert not main((str(f), '--exit-zero-even-if-changed'))
+
+
+def test_success_messages_are_printed_on_stderr(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write('import os,sys')
+    main((str(f),))
+    out, err = capsys.readouterr()
+    assert err == 'Reordering imports in {}\n'.format(f)
+    assert out == ''


### PR DESCRIPTION
Changed the output stream of success user messages from _stdout_ to _stderr_. _Stdout_ is now used for data output only. This is what UNIX tool should behave like.