### PR TITLE
Add application module option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Common options:
   import roots live.  For example, when using the popular `./src` layout you'd
   use `--application-directories=.:src` (note: multiple paths are separated
   using a `:`).
+- `--unclassifiable-application-module`: (may be specified multiple times)
+  modules names that are considered application modules.  this setting is
+  intended to be used for things like C modules which may not always appear on
+  the filesystem.
 
 ## As a pre-commit hook
 

--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -475,6 +475,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
         separate_relative=args.separate_relative,
         separate_from_import=args.separate_from_import,
         application_directories=args.application_directories.split(':'),
+        unclassifiable_application_modules=args.unclassifiable,
     )
     if filename == '-':
         print(new_contents, end='')
@@ -717,6 +718,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help=(
             'Colon separated directories that are considered top-level '
             'application directories.  Defaults to `%(default)s`'
+        ),
+    )
+    parser.add_argument(
+        '--unclassifiable-application-module', action='append', default=[],
+        dest='unclassifiable',
+        help=(
+            '(may be specified multiple times) module names that are '
+            'considered application modules.  this setting is intended to be '
+            'used for things like C modules which may not always appear on '
+            'the filesystem'
         ),
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 [options]
 py_modules = reorder_python_imports
 install_requires =
-    aspy.refactor_imports>=0.5.3
+    aspy.refactor_imports>=2.1.0
 python_requires = >=3.6.1
 
 [options.entry_points]

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -434,6 +434,22 @@ def test_apply_import_sorting_sorts_imports_with_separate_from_import():
     ]
 
 
+def test_apply_import_sorting_sorts_imports_with_application_module():
+    assert apply_import_sorting(
+        [
+            CodePartition(CodeType.IMPORT, 'import _c_module\n'),
+            CodePartition(CodeType.IMPORT, 'import reorder_python_imports\n'),
+            CodePartition(CodeType.IMPORT, 'import third_party\n'),
+        ],
+        unclassifiable_application_modules=['_c_module'],
+    ) == [
+        CodePartition(CodeType.IMPORT, 'import third_party\n'),
+        CodePartition(CodeType.NON_CODE, '\n'),
+        CodePartition(CodeType.IMPORT, 'import _c_module\n'),
+        CodePartition(CodeType.IMPORT, 'import reorder_python_imports\n'),
+    ]
+
+
 def test_apply_import_sorting_maintains_comments():
     input_partitions = [
         CodePartition(CodeType.IMPORT, 'import foo  # noqa\n'),


### PR DESCRIPTION
Whilst using this great tool for https://github.com/tskit-dev/tskit I found that the C API module was being categorised as THIRD_PARTY. As this module might not have been compiled and therefore not exist there is no way for the code to know this was the case. I've therefore added an `application_module` option that overrides the categorisation.