### PR TITLE
Stop inserting spurious newline with --separate-relative

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -384,7 +384,11 @@ def apply_import_sorting(
         if last_import_obj is not None:
             new_imports.append(CodePartition(CodeType.NON_CODE, '\n'))
 
-    if relative_imports:
+    # There is another edge case if --separate-relative is passed while all the
+    # imports are relative. In that case we don't want an empty new line at the
+    # beginning of the block. We should insert the new line only if there are
+    # additional blocks.  See #134
+    if relative_imports and len(sorted_blocks) > 1:
         relative_imports.insert(0, CodePartition(CodeType.NON_CODE, '\n'))
     # XXX: I want something like [x].join(...) (like str join) but for now
     # this works

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -891,6 +891,14 @@ def test_separate_relative_and_separate_from():
     )
 
 
+def test_separate_relative_when_only_relative_imports_are_present():
+    src = (
+        'from . import bar\n'
+        'from . import foo\n'
+    )
+    assert fix_file_contents(src, separate_relative=True) == src
+
+
 def test_fix_crlf():
     s = (
         '"""foo"""\r\n'


### PR DESCRIPTION
Until now, if the module contained only relative imports and
`--separate-relative` was passed, then a spurious newline was added at the
beginnning of the file. With this commit the newline is added only when
there are additional import blocks.

Fixes #134