### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 py_modules = reorder_python_imports
 install_requires =
     aspy.refactor-imports>=2.1.0
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/testing/generate-future-info
+++ b/testing/generate-future-info
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import __future__
+from __future__ import annotations
 
+import __future__  # noreorder
 import collections
 import os.path
 import sys

--- a/testing/generate-mock-info
+++ b/testing/generate-mock-info
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 import sys
 import unittest.mock

--- a/testing/generate-python-future-info
+++ b/testing/generate-python-future-info
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import builtins
 import os.path
 import sys

--- a/testing/generate-six-info
+++ b/testing/generate-six-info
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os.path
 import sys
 

--- a/testing/generate-typing-pep585-rewrites
+++ b/testing/generate-typing-pep585-rewrites
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os.path
 import sys
 import typing.re

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 import sys
 from collections import defaultdict
-from typing import Dict
-from typing import List
-from typing import Set
-from typing import Tuple
 
 import flake8_typing_imports
 import mypy_extensions
@@ -30,7 +28,7 @@ def main() -> int:
     )
 
     # some attrs are removed and then added back
-    min_contiguous_versions: Dict[str, flake8_typing_imports.Version] = {}
+    min_contiguous_versions: dict[str, flake8_typing_imports.Version] = {}
     for v, attrs in flake8_typing_imports.SYMBOLS:
         for removed in set(min_contiguous_versions) - attrs:
             del min_contiguous_versions[removed]
@@ -38,27 +36,27 @@ def main() -> int:
         for attr in attrs:
             min_contiguous_versions.setdefault(attr, v)
 
-    symbols: Dict[flake8_typing_imports.Version, Set[str]] = defaultdict(set)
+    symbols: dict[flake8_typing_imports.Version, set[str]] = defaultdict(set)
     for a, v in min_contiguous_versions.items():
         symbols[v].add(a)
 
     # --pyXX-plus assumes the min --pyXX so group symbols by their
     # rounded up major version
-    symbols_rounded_up: Dict[Tuple[int, int], Set[str]] = defaultdict(set)
+    symbols_rounded_up: dict[tuple[int, int], set[str]] = defaultdict(set)
     for v, attrs in sorted(symbols.items()):
         symbols_rounded_up[v.major, v.minor + int(v.patch != 0)] |= attrs
 
-    # combine 3.5 and 3.6 because this lib is 3.6.1+
+    # combine 3.5 and 3.6 because this lib is 3.7+
     symbols_rounded_up[(3, 6)] |= symbols_rounded_up.pop((3, 5))
 
-    deltas: Dict[Tuple[int, int], Set[str]] = defaultdict(set)
-    prev: Set[str] = set()
+    deltas: dict[tuple[int, int], set[str]] = defaultdict(set)
+    prev: set[str] = set()
     for v, attrs in sorted(symbols_rounded_up.items()):
         deltas[v] = attrs - prev
         prev = attrs
 
-    mypy_extensions_added: Dict[Tuple[int, int], List[str]] = {}
-    typing_extensions_added: Dict[Tuple[int, int], List[str]] = {}
+    mypy_extensions_added: dict[tuple[int, int], list[str]] = {}
+    typing_extensions_added: dict[tuple[int, int], list[str]] = {}
     for v, attrs in deltas.items():
         mypy_extensions_added[v] = sorted(attrs & mypy_extensions_all)
         typing_extensions_added[v] = sorted(attrs & typing_extensions_all)

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import io
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos