### PR TITLE
Teach --py3-plus to rewrite direct six module imports

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -244,6 +244,17 @@ def replace_imports(
                         new_src = import_obj.to_text()
                         yield partition._replace(src=new_src)
                         break
+                    # from a.b.c import d => from c import d
+                    elif (
+                        not attr and
+                        (mod_parts + [symbol] == orig_mod) and
+                        len(new_mod) > 1 and
+                        symbol == new_mod[-1]
+                    ):
+                        import_obj.ast_obj.module = '.'.join(new_mod[:-1])
+                        new_src = import_obj.to_text()
+                        yield partition._replace(src=new_src)
+                        break
                     # from x.y import z => import z
                     elif (
                             not attr and

--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -249,9 +249,12 @@ def replace_imports(
                         (mod_parts + [symbol] == orig_mod) and
                         not attr and
                         len(new_mod) > 1 and
-                        symbol == new_mod[-1]
+                        (asname or symbol == new_mod[-1])
                     ):
                         import_obj.ast_obj.module = '.'.join(new_mod[:-1])
+                        import_obj.ast_obj.names = [
+                            ast.alias(name=new_mod[-1], asname=asname),
+                        ]
                         new_src = import_obj.to_text()
                         yield partition._replace(src=new_src)
                         break

--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -246,8 +246,8 @@ def replace_imports(
                         break
                     # from a.b.c import d => from c import d
                     elif (
-                        not attr and
                         (mod_parts + [symbol] == orig_mod) and
+                        not attr and
                         len(new_mod) > 1 and
                         symbol == new_mod[-1]
                     ):

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -527,7 +527,9 @@ def test_replace_module_imported_asname():
 def test_replace_module_imported_with_nested_replacement():
     ret = fix_file_contents(
         'from six.moves.urllib import parse\n',
-        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], '')],
+        imports_to_replace=[
+            (['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], ''),
+        ],
     )
     assert ret == 'from urllib import parse\n'
 
@@ -535,15 +537,19 @@ def test_replace_module_imported_with_nested_replacement():
 def test_replace_module_imported_with_nested_replacement_asname():
     ret = fix_file_contents(
         'from six.moves.urllib import parse as urllib_parse\n',
-        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], '')],
+        imports_to_replace=[
+            (['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], ''),
+        ],
     )
     assert ret == 'from urllib import parse as urllib_parse\n'
 
 
-def test_replace_module_imported_with_nested_replacement_asname2():
+def test_replace_module_imported_with_nested_renamed_replacement_asname():
     ret = fix_file_contents(
         'from six.moves.urllib import parse as urllib_parse\n',
-        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse2'], '')],
+        imports_to_replace=[
+            (['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse2'], ''),
+        ],
     )
     assert ret == 'from urllib import parse2 as urllib_parse\n'
 
@@ -551,7 +557,9 @@ def test_replace_module_imported_with_nested_replacement_asname2():
 def test_replace_module_skips_attr_specific_rules():
     ret = fix_file_contents(
         'from libone import util\n',
-        imports_to_replace=[(['libone', 'util'], ['libtwo', 'util'], 'is_valid')],
+        imports_to_replace=[
+            (['libone', 'util'], ['libtwo', 'util'], 'is_valid'),
+        ],
     )
     assert ret == 'from libone import util\n'
 

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -745,6 +745,13 @@ def test_py_options(tmpdir, opt, expected):
     assert f.read() == expected
 
 
+def test_py3_plus_unsixes_imports_rename_directly_imported_module(tmpdir):
+    f = tmpdir.join('f.py')
+    f.write('from six.moves.urllib import parse\n')
+    assert main((str(f), '--py3-plus'))
+    assert f.read() == 'from urllib import parse\n'
+
+
 def test_py3_plus_unsixes_imports_rename_module(tmpdir):
     f = tmpdir.join('f.py')
     f.write('from six.moves.urllib.parse import quote_plus\n')

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -524,12 +524,45 @@ def test_replace_module_imported_asname():
     assert ret == 'import queue as Queue\n'
 
 
-def test_replace_module__imported_as_from():
+def test_replace_module_imported_with_nested_replacement():
     ret = fix_file_contents(
         'from six.moves.urllib import parse\n',
         imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], '')],
     )
     assert ret == 'from urllib import parse\n'
+
+
+def test_replace_module_imported_with_nested_replacement_asname():
+    ret = fix_file_contents(
+        'from six.moves.urllib import parse as urllib_parse\n',
+        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], '')],
+    )
+    assert ret == 'from urllib import parse as urllib_parse\n'
+
+
+@pytest.mark.xfail(reason='TODO')
+def test_replace_module_imported_with_nested_replacement_asname2():
+    ret = fix_file_contents(
+        'from six.moves.urllib import parse as urllib_parse\n',
+        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse2'], '')],
+    )
+    assert ret == 'from urllib import parse2 as urllib_parse\n'
+
+
+def test_replace_module_skips_attr_specific_rules():
+    ret = fix_file_contents(
+        'from libone import util\n',
+        imports_to_replace=[(['libone', 'util'], ['libtwo', 'util'], 'is_valid')],
+    )
+    assert ret == 'from libone import util\n'
+
+
+def test_replace_module_skips_nonmatching_rules():
+    ret = fix_file_contents(
+        'from libthree import util\n',
+        imports_to_replace=[(['libone', 'util'], ['libtwo', 'util'], '')],
+    )
+    assert ret == 'from libthree import util\n'
 
 
 cases = pytest.mark.parametrize(

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -524,6 +524,14 @@ def test_replace_module_imported_asname():
     assert ret == 'import queue as Queue\n'
 
 
+def test_replace_module__imported_as_from():
+    ret = fix_file_contents(
+        'from six.moves.urllib import parse\n',
+        imports_to_replace=[(['six', 'moves', 'urllib', 'parse'], ['urllib', 'parse'], '')],
+    )
+    assert ret == 'from urllib import parse\n'
+
+
 cases = pytest.mark.parametrize(
     ('s', 'expected'),
     (
@@ -743,13 +751,6 @@ def test_py_options(tmpdir, opt, expected):
     )
     main((str(f), opt))
     assert f.read() == expected
-
-
-def test_py3_plus_unsixes_imports_rename_directly_imported_module(tmpdir):
-    f = tmpdir.join('f.py')
-    f.write('from six.moves.urllib import parse\n')
-    assert main((str(f), '--py3-plus'))
-    assert f.read() == 'from urllib import parse\n'
 
 
 def test_py3_plus_unsixes_imports_rename_module(tmpdir):

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -540,7 +540,6 @@ def test_replace_module_imported_with_nested_replacement_asname():
     assert ret == 'from urllib import parse as urllib_parse\n'
 
 
-@pytest.mark.xfail(reason='TODO')
 def test_replace_module_imported_with_nested_replacement_asname2():
     ret = fix_file_contents(
         'from six.moves.urllib import parse as urllib_parse\n',


### PR DESCRIPTION
Impetus for this is to automatically rewrite
`from six.moves.urllib import parse` to `from urllib import parse`.