### PR TITLE
README: make install command a code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ uses static analysis more.
 
 ## Installation
 
-`pip install reorder-python-imports`
+```bash
+pip install reorder-python-imports
+```
 
 
 ## Console scripts


### PR DESCRIPTION
When using a full Codeblocks on GitHub, it can be copied to clipboard by just klicking it. This is verry handy, especcially for the import cammand, that needs to be copied regularly. 

I made this PR because it anoyed me that I had to drag the mouse accross the command, so defnetly a "I am super lazy" problem. 