### PR TITLE
Moved get_type_hints() to the 3.9 level

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -419,7 +419,7 @@ REMOVALS[(3, 7)].add('from __future__ import generator_stop')
 
 # GENERATED VIA generate-typing-rewrite-info
 # Using:
-#     flake8-typing-imports==1.12.0
+#     flake8-typing-imports==1.13.0
 #     mypy-extensions==0.4.3
 #     typing-extensions==4.3.0
 REPLACES[(3, 6)].update((
@@ -434,7 +434,6 @@ REPLACES[(3, 6)].update((
     'typing_extensions=typing:TYPE_CHECKING',
     'typing_extensions=typing:Text',
     'typing_extensions=typing:Type',
-    'typing_extensions=typing:get_type_hints',
 ))
 REPLACES[(3, 7)].update((
     'mypy_extensions=typing:NoReturn',
@@ -456,6 +455,7 @@ REPLACES[(3, 8)].update((
 ))
 REPLACES[(3, 9)].update((
     'typing_extensions=typing:Annotated',
+    'typing_extensions=typing:get_type_hints',
 ))
 REPLACES[(3, 10)].update((
     'typing_extensions=typing:Concatenate',

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -17,6 +17,7 @@ else:
 
 # --- typing_extensions notes ---
 # https://github.com/python/typing_extensions#other-notes-and-limitations
+# - Starting with Python 3.9, get_type_hints() has the include_extra parameter
 # - get_origin and get_args lack support for Annotated in Python 3.8
 #   and lack support for ParamSpecArgs and ParamSpecKwargs in 3.9.
 # - Starting with 3.11, NamedTuple and TypedDict can inherit from Generic
@@ -24,6 +25,7 @@ else:
 # - @overload was changed in Python 3.11 to make function overloads
 #   introspectable at runtime.
 CUSTOM_TYPING_EXT_SYMBOLS = {
+    (3, 9): {'get_type_hints'},
     (3, 10): {'get_origin', 'get_args'},
     (3, 11): {'NamedTuple', 'TypedDict', 'final', 'overload'},
 }


### PR DESCRIPTION
This function gained an extra parameter, "include_extras", in Python 3.9, and this parameter is provided by the typing_extensions implementation.