### PR TITLE
Add a '--no-exit-zero-even-if-changed' flag

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -733,6 +733,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument(
+        '--no-exit-zero-even-if-changed', action='store_false',
+        dest='exit_zero_even_if_changed', help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         '--add-import', action='append', default=[], type=_validate_import,
         help='Import to add to each file.  Can be specified multiple times.',
     )

--- a/tests/reorder_python_imports_test.py
+++ b/tests/reorder_python_imports_test.py
@@ -1280,6 +1280,20 @@ def test_exit_zero_even_if_changed(tmpdir):
     assert not main((str(f), '--exit-zero-even-if-changed'))
 
 
+def test_no_exit_zero_even_if_changed(tmpdir):
+    f = tmpdir.join('t.py')
+    f.write('import os,sys')
+    assert main((str(f), '--no-exit-zero-even-if-changed'))
+    assert f.read() == 'import os\nimport sys\n'
+    assert main((str(f), '--no-exit-zero-even-if-changed'))
+    assert main((
+        str(f), '--exit-zero-even-if-changed --no-exit-zero-even-if-changed',
+    ))
+    assert not main((
+        str(f), '--no-exit-zero-even-if-changed --exit-zero-even-if-changed',
+    ))
+
+
 def test_success_messages_are_printed_on_stderr(tmpdir, capsys):
     f = tmpdir.join('f.py')
     f.write('import os,sys')


### PR DESCRIPTION
Enables an user to cancel out a previous flag that might have been set.

A example use case is when a Makefile uses `--exit-zero-even-if-changed` as part of the command line, but the flag isn't set in a variable. This enables the Makefile user to add flags via Makefile variable (such as `--py39-plus` or `--py310-plus`) without forcing the user to re-specify `--exit-zero-even-if-changed` and thus break the Makefile handling of errors.

But, in the case of the CI, it's more likely required that the same Makefile command will require the absence of `--exit-zero-even-if-changed`. Unfortunatly, once specified, it can't be canceled out.

The hidden `--no-exit-zero-even-if-changed` enables the cancelling out of the option. It's hidden to avoid clutter for the `--help` command.

