### PR TITLE
Update typing rewrites for typing_extensions 4.4.0

### DIFF
--- a/reorder_python_imports.py
+++ b/reorder_python_imports.py
@@ -421,7 +421,7 @@ REMOVALS[(3, 7)].add('from __future__ import generator_stop')
 # Using:
 #     flake8-typing-imports==1.13.0
 #     mypy-extensions==0.4.3
-#     typing-extensions==4.3.0
+#     typing-extensions==4.4.0
 REPLACES[(3, 6)].update((
     'typing_extensions=typing:AsyncIterable',
     'typing_extensions=typing:AsyncIterator',
@@ -459,7 +459,6 @@ REPLACES[(3, 9)].update((
 ))
 REPLACES[(3, 10)].update((
     'typing_extensions=typing:Concatenate',
-    'typing_extensions=typing:ParamSpec',
     'typing_extensions=typing:ParamSpecArgs',
     'typing_extensions=typing:ParamSpecKwargs',
     'typing_extensions=typing:TypeAlias',

--- a/testing/generate-typing-rewrite-info
+++ b/testing/generate-typing-rewrite-info
@@ -24,10 +24,15 @@ else:
 # - @final was changed in Python 3.11 to set the .__final__ attribute
 # - @overload was changed in Python 3.11 to make function overloads
 #   introspectable at runtime.
+# - Any was change in Python 3.11 so it can be used as a base class
+# - Considered for Python 3.12
+#   - PEP 695 infer_variance parameter for TypeVar
+#   - PEP 696 default parameter for TypeVar, TypeVarTuple, and ParamSpec
 CUSTOM_TYPING_EXT_SYMBOLS = {
     (3, 9): {'get_type_hints'},
     (3, 10): {'get_origin', 'get_args'},
-    (3, 11): {'NamedTuple', 'TypedDict', 'final', 'overload'},
+    (3, 11): {'Any', 'NamedTuple', 'TypedDict', 'final', 'overload'},
+    (3, 12): {'ParamSpec', 'TypeVar', 'TypeVarTuple'},
 }
 
 


### PR DESCRIPTION
Version `4.4.0` for `typing_extensions` was released today.
https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-440-october-6-2022

The version includes custom implementations for `Any`, `TypeVar`, `TypeVarTuple`, and `ParamSpec`.
Update the `generate-typing-rewrite-info` script to prevent accidental rewrites.

_As requested previously https://github.com/asottile/reorder_python_imports/pull/289#pullrequestreview-1042752577, I deleted the sections for `3.11` and `3.12` from the output._

Ref: https://github.com/python/typing_extensions#other-notes-and-limitations